### PR TITLE
フラッシュメッセージの実装

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,8 +7,4 @@
     = javascript_include_tag 'application', 'data-turbolinks-track' => true
     = csrf_meta_tags
   %body
-  .contents
-    .header
-      - flash.each do |key, value|
-        = content_tag(:div, value, class: "#{key}")
     = yield

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,5 +8,7 @@
     = csrf_meta_tags
   %body
   .contents
-    .header #{flash[:notice]}
+    .header
+      - flash.each do |key, value|
+        = content_tag(:div, value, class: "#{key}")
     = yield

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,4 +7,6 @@
     = javascript_include_tag 'application', 'data-turbolinks-track' => true
     = csrf_meta_tags
   %body
+  .contents
+    .header #{flash[:notice]}
     = yield

--- a/app/views/messages/_left_contents.html.haml
+++ b/app/views/messages/_left_contents.html.haml
@@ -1,0 +1,11 @@
+.left-content
+  .left-header
+    .left-header__name #{current_user.name}
+    = link_to edit_user_registration_path do
+      %i.fa.fa-gear.left-header__gear
+    = link_to "http://google.co.jp" do
+      %i.fa.fa-edit.left-header__edit
+  %ul.left-main
+    .group-list
+      - ["sample", "sample2", "sample3", "sample4", "sample5", "sample6", "sample7", "sample8", "sample9", "sample10"].each do |name|
+        = render 'group', group_name: name

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,16 +1,6 @@
 .contents
   = render 'shared/flash'
-  .left-content
-    .left-header
-      .left-header__name #{current_user.name}
-      = link_to edit_user_registration_path do
-        %i.fa.fa-gear.left-header__gear
-      = link_to "http://google.co.jp" do
-        %i.fa.fa-edit.left-header__edit
-    %ul.left-main
-      .group-list
-        - ["sample", "sample2", "sample3", "sample4", "sample5", "sample6", "sample7", "sample8", "sample9", "sample10"].each do |name|
-          = render 'group', group_name: name
+  = render 'left_contents'
   .right-margin
     .right-content
       .right-header

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -2,7 +2,7 @@
   = render 'shared/flash'
   .left-content
     .left-header
-      .left-header__name takuma
+      .left-header__name #{current_user.name}
       = link_to edit_user_registration_path do
         %i.fa.fa-gear.left-header__gear
       = link_to "http://google.co.jp" do

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,28 +1,30 @@
-.left-content
-  .left-header
-    .left-header__name takuma
-    = link_to edit_user_registration_path do
-      %i.fa.fa-gear.left-header__gear
-    = link_to "http://google.co.jp" do
-      %i.fa.fa-edit.left-header__edit
-  %ul.left-main
-    .group-list
-      - ["sample", "sample2", "sample3", "sample4", "sample5", "sample6", "sample7", "sample8", "sample9", "sample10"].each do |name|
-        = render 'group', group_name: name
-.right-margin
-  .right-content
-    .right-header
-      .right-header__group-info
-        .right-header__group-info__name sample
-        .right-header__group-info__members Members: neko takuma
-      .right-header__edit-button Edit
-    .right-main
-      %ul.message-list
-        - ["Hello world!","Good bey world!","Good bey world!","Good bey world!","Good bey world!","Good bey world!","Good bey world!","Good bey world!","Good bey world!", "test"].each do |message|
-          = render 'message', text: message
-    .right-footer
-      %form.input-form{action: "/", method: "post"}
-        %input.input-form__message{name: "message", type: "text", placeholder: "type a message"}
-        = link_to "http://google.co.jp" do
-          %i.fa.fa-picture-o.input-form__image
-        %input.input-form__send-button{type: "submit", value: "Send"}
+.contents
+  = render 'shared/flash'
+  .left-content
+    .left-header
+      .left-header__name takuma
+      = link_to edit_user_registration_path do
+        %i.fa.fa-gear.left-header__gear
+      = link_to "http://google.co.jp" do
+        %i.fa.fa-edit.left-header__edit
+    %ul.left-main
+      .group-list
+        - ["sample", "sample2", "sample3", "sample4", "sample5", "sample6", "sample7", "sample8", "sample9", "sample10"].each do |name|
+          = render 'group', group_name: name
+  .right-margin
+    .right-content
+      .right-header
+        .right-header__group-info
+          .right-header__group-info__name sample
+          .right-header__group-info__members Members: neko takuma
+        .right-header__edit-button Edit
+      .right-main
+        %ul.message-list
+          - ["Hello world!","Good bey world!","Good bey world!","Good bey world!","Good bey world!","Good bey world!","Good bey world!","Good bey world!","Good bey world!", "test"].each do |message|
+            = render 'message', text: message
+      .right-footer
+        %form.input-form{action: "/", method: "post"}
+          %input.input-form__message{name: "message", type: "text", placeholder: "type a message"}
+          = link_to "http://google.co.jp" do
+            %i.fa.fa-picture-o.input-form__image
+          %input.input-form__send-button{type: "submit", value: "Send"}

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,30 +1,28 @@
-.contents
-  .header チャットグループが作成されました。
-  .left-content
-    .left-header
-      .left-header__name takuma
-      = link_to edit_user_registration_path do
-        %i.fa.fa-gear.left-header__gear
-      = link_to "http://google.co.jp" do
-        %i.fa.fa-edit.left-header__edit
-    %ul.left-main
-      .group-list
-        - ["sample", "sample2", "sample3", "sample4", "sample5", "sample6", "sample7", "sample8", "sample9", "sample10"].each do |name|
-          = render 'group', group_name: name
-  .right-margin
-    .right-content
-      .right-header
-        .right-header__group-info
-          .right-header__group-info__name sample
-          .right-header__group-info__members Members: neko takuma
-        .right-header__edit-button Edit
-      .right-main
-        %ul.message-list
-          - ["Hello world!","Good bey world!","Good bey world!","Good bey world!","Good bey world!","Good bey world!","Good bey world!","Good bey world!","Good bey world!", "test"].each do |message|
-            = render 'message', text: message
-      .right-footer
-        %form.input-form{action: "/", method: "post"}
-          %input.input-form__message{name: "message", type: "text", placeholder: "type a message"}
-          = link_to "http://google.co.jp" do
-            %i.fa.fa-picture-o.input-form__image
-          %input.input-form__send-button{type: "submit", value: "Send"}
+.left-content
+  .left-header
+    .left-header__name takuma
+    = link_to edit_user_registration_path do
+      %i.fa.fa-gear.left-header__gear
+    = link_to "http://google.co.jp" do
+      %i.fa.fa-edit.left-header__edit
+  %ul.left-main
+    .group-list
+      - ["sample", "sample2", "sample3", "sample4", "sample5", "sample6", "sample7", "sample8", "sample9", "sample10"].each do |name|
+        = render 'group', group_name: name
+.right-margin
+  .right-content
+    .right-header
+      .right-header__group-info
+        .right-header__group-info__name sample
+        .right-header__group-info__members Members: neko takuma
+      .right-header__edit-button Edit
+    .right-main
+      %ul.message-list
+        - ["Hello world!","Good bey world!","Good bey world!","Good bey world!","Good bey world!","Good bey world!","Good bey world!","Good bey world!","Good bey world!", "test"].each do |message|
+          = render 'message', text: message
+    .right-footer
+      %form.input-form{action: "/", method: "post"}
+        %input.input-form__message{name: "message", type: "text", placeholder: "type a message"}
+        = link_to "http://google.co.jp" do
+          %i.fa.fa-picture-o.input-form__image
+        %input.input-form__send-button{type: "submit", value: "Send"}

--- a/app/views/shared/_flash.html.haml
+++ b/app/views/shared/_flash.html.haml
@@ -1,0 +1,3 @@
+.header
+  - flash.each do |key, value|
+    = content_tag(:div, value, class: "#{key}")

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,5 +11,7 @@ module ChatSpace
       g.helper false
       g.test_framework false
     end
+
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,57 @@
+ja:
+  devise:
+    confirmations:
+      confirmed: "アカウントが確認されました。ログインしています。"
+      send_instructions: "アカウントの確認方法を数分以内にメールでご連絡します。"
+      send_paranoid_instructions: "ご登録のメールアドレスが保存されている場合、アカウントの確認方法をメールでご連絡します。"
+    failure:
+      already_authenticated: "既にログインしています。"
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid email or password."
+      locked: "アカウントがロックされています。"
+      last_attempt: "あなたのアカウントがロックされる前に、もう1つの試みを持っています。"
+      not_found_in_database: "メールアドレスまたはパスワードが無効です。"
+      timeout: "一定時間が経過したため、再度ログインが必要です"
+      unauthenticated: "ログインまたは登録が必要です。"
+      unconfirmed: "本登録を行ってください。"
+    mailer:
+      confirmation_instructions:
+        subject: "アカウントの登録方法"
+      reset_password_instructions:
+        subject: "パスワードの再設定"
+      unlock_instructions:
+        subject: "アカウントのロック解除"
+    omniauth_callbacks:
+      failure: "%{kind} から承認されませんでした。理由：%{reason}"
+      success: "%{kind} から承認されました。"
+    passwords:
+      no_token: "このページにアクセスする事が出来ません。正しいURLでアクセスしている事を確認して下さい。"
+      send_instructions: "パスワードのリセット方法を数分以内にメールでご連絡します。"
+      send_paranoid_instructions: ""
+      updated: "パスワードを変更しました。"
+      updated_not_active: "パスワードを変更しました。"
+    registrations:
+      destroyed: "アカウントを削除しました。またのご利用をお待ちしております。"
+      signed_up: "アカウント登録を受け付けました。"
+      signed_up_but_inactive: "アカウントは登録されていますが、アクティブになっていないため利用できません。"
+      signed_up_but_locked: "アカウントは登録されていますが、ロックされているため利用できません。"
+      signed_up_but_unconfirmed: "確認メールを登録したメールアドレス宛に送信しました。リンクを開いてアカウントを有効にして下さい。"
+      update_needs_confirmation: "アカウント情報が更新されました。更新の確認メールを新しいメールアドレス宛に送信しましたので、リンクを開いて更新を有効にして下さい。"
+      updated: "アカウントが更新されました。"
+    sessions:
+      signed_in: "ログインしました。"
+      signed_out: "ログアウトしました。"
+    unlocks:
+      send_instructions: "アカウントのロックを解除する方法を数分以内にメールでご連絡します。"
+      send_paranoid_instructions: "アカウントが存在する場合、ロックを解除する方法をメールでご連絡します。"
+      unlocked: "アカウントのロックが解除されました。ログインしています。"
+  errors:
+    messages:
+      already_confirmed: "は既に登録済みです。ログインしてください"
+      confirmation_period_expired: "%{period}以内に確認する必要がありますので、新しくリクエストしてください。"
+      expired: "有効期限切れです。新規登録してください。"
+      not_found: "は見つかりませんでした。"
+      not_locked: "ロックされていません。"
+      not_saved:
+        one: "エラーにより、この %{resource} を保存できません："
+        other: "%{count} 個のエラーにより、この %{resource} を保存できません："


### PR DESCRIPTION
# WHAT
以下のとき、フラッシュメッセージを表示する。
+ サインイン成功時 / サインイン失敗時
+ サインアップ成功時 /　サインアップ失敗時
+ サインアウト成功時
+ ユーザー情報編集成功時

deviseからのフラッシュメッセージをheaderに表示できるようにする。
deviseの日本語化を行う。

# WHY
処理結果確認の機能